### PR TITLE
Feat--キーワード検索：作成日：並び替えの機能

### DIFF
--- a/src/public/memo.php
+++ b/src/public/memo.php
@@ -7,10 +7,24 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
+// キーワードのデータを変数に代入
+$search = isset($_GET['search']) ? '%' . $_GET["search"] . '%' : '%%';
+
+// 指定された並び替えのデータを変数に代入
+$order = isset($_GET['order']) ? $_GET['order'] : '';
+
+// キーワードが含まれるデータを取得
+$sql = 'SELECT * FROM pages WHERE name LIKE :search OR contents LIKE :search';
+
+// 並び替えの指定を設定
+if ($order === 'asc') {
+  $sql .= ' ORDER BY created_at ASC';
+} else {
+  $sql .= ' ORDER BY created_at DESC'; 
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':search', $search, PDO::PARAM_STR);
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -27,9 +41,11 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 <body>
   <div>
-    <div>
-      <form action="index.php" method="get">
-        <div>
+    <!-- キーワード検索フォームの作成 -->
+    <form action="memo.php" method="get">
+      <input type="text" name="search"><br>
+      <div>
+      <!-- 作成日の並び替えフォーム -->
           <label>
             <input type="radio" name="order" value="desc" class="">
             <span>新着順</span>
@@ -40,7 +56,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
           </label>
         </div>
         <button type="submit">送信</button>
-      </form>
+    </form>
     </div>
 
     <div>

--- a/src/public/mypage.php
+++ b/src/public/mypage.php
@@ -7,10 +7,17 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
+if (isset($_GET['search'])) {
+  $name = '%' . $_GET["search"].'%';
+  $contents = '%' . $_GET["search"].'%';
+} else {
+  $name = '%%';
+  $contents = '%%';
+}
+$sql = 'SELECT * FROM pages WHERE name LIKE :name OR contents LIKE :contents';
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':name', $name, PDO::PARAM_STR);
+$statement->bindValue(':contents', $contents, PDO::PARAM_STR);
 
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -28,7 +35,10 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 <body>
   <div>
-
+    <form action="mypage.php" method="get">
+      <input type="text" name="search"><br>
+      <input type="submit">
+    </form>
     <div>
       <form action="index.php" method="get">
         <div>

--- a/src/public/mytop.php
+++ b/src/public/mytop.php
@@ -7,10 +7,31 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
+// キーワードのデータを変数に代入
+$keyword = isset($_GET['search']) ? '%' . $_GET['search'] .'%' : '%%';
+
+// 期間の作成日フォームの変数
+$start_date = isset($_GET['start_date']) ? $_GET['start_date'] : '';
+$end_date = isset($_GET['end_date']) ? $_GET['end_date'] : '';
+
+
+// キーワードが含まれるデータを取得
+$sql = 'SELECT * FROM pages WHERE (name LIKE :search OR contents LIKE :search)';
+
+// 期間の作成日が送信された場合のデータ取得
+if (!empty($start_date) && !empty($end_date)) {
+  $sql .= ' AND created_at BETWEEN :start_date AND :end_date';
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':search', $keyword, PDO::PARAM_STR);
+
+// 期間の作成日が送信された場合のバインド
+if (!empty($start_date) && !empty($end_date)) {
+  $statement->bindValue(':start_date', $start_date, PDO::PARAM_STR);
+  $statement->bindValue(':end_date', $end_date, PDO::PARAM_STR);
+}
+
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -27,21 +48,17 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 <body>
   <div>
-    <div>
-      <form action="index.php" method="get">
-        <div>
-          <label>
-            <input type="radio" name="order" value="desc" class="">
-            <span>新着順</span>
-          </label>
-          <label>
-            <input type="radio" name="order" value="asc" class="">
-            <span>古い順</span>
-          </label>
-        </div>
+    <form action="mytop.php" method="get">
+      <!-- 検索フォーム -->
+      <input type="text" name="search" placeholder="検索ワードを入力"><br>
+        <!-- 期間の作成日フォーム -->
+          <label>期間指定：</label>
+          <input type="date" name="start_date" value="<?php echo $start_date; ?>" required>
+          <label>～</label>
+          <input type="date" name="end_date" value="<?php echo $end_date; ?>" required>
         <button type="submit">送信</button>
       </form>
-    </div>
+  </div>
 
     <div>
       <table border="1">

--- a/src/public/page.php
+++ b/src/public/page.php
@@ -7,10 +7,21 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+// 期間の作成日フォームの変数
+$start_date = isset($_GET['start_date']) ? $_GET['start_date'] : '';
+$end_date = isset($_GET['end_date']) ? $_GET['end_date'] : '';
+
+// 期間の作成日が送信された場合のデータ取得
+if (!empty($start_date) && !empty($end_date)) {
+  $sql = 'SELECT * FROM pages WHERE created_at BETWEEN :start_date AND :end_date';
+  $statement = $pdo->prepare($sql);
+  $statement->bindValue(':start_date', $start_date, PDO::PARAM_STR);
+  $statement->bindValue(':end_date', $end_date, PDO::PARAM_STR);
+  // 期間の作成日が送信されない場合
+} else {
+  $sql = 'SELECT * FROM pages';
+  $statement = $pdo->prepare($sql);
+}
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -28,16 +39,13 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 <body>
   <div>
     <div>
-      <form action="index.php" method="get">
+      <form action="page.php" method="get">
         <div>
-          <label>
-            <input type="radio" name="order" value="desc" class="">
-            <span>新着順</span>
-          </label>
-          <label>
-            <input type="radio" name="order" value="asc" class="">
-            <span>古い順</span>
-          </label>
+        <!-- 期間の作成日フォーム -->
+          <label>期間指定：</label>
+          <input type="date" name="start_date" value="<?php echo $start_date; ?>" required>
+          <label>～</label>
+          <input type="date" name="end_date" value="<?php echo $end_date; ?>" required>
         </div>
         <button type="submit">送信</button>
       </form>

--- a/src/public/privatepage.php
+++ b/src/public/privatepage.php
@@ -7,11 +7,18 @@ $pdo = new PDO(
     $dbPassword
 );
 
+// 指定された並び替えのデータを変数に代入
+$order = isset($_GET['order']) ? $_GET['order'] : '';
 $sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
 
+// 並び替えの指定を設定
+if ($order === 'asc') {
+  $sql .= ' ORDER BY created_at ASC';
+} else {
+  $sql .= ' ORDER BY created_at DESC'; 
+}
+
+$statement = $pdo->prepare($sql);
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -29,7 +36,8 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 <body>
   <div>
     <div>
-      <form action="index.php" method="get">
+      <!-- 作成日の並び替えフォーム -->
+      <form action="privatepage.php" method="get">
         <div>
           <label>
             <input type="radio" name="order" value="desc" class="">

--- a/src/public/privatetop.php
+++ b/src/public/privatetop.php
@@ -6,11 +6,36 @@ $pdo = new PDO(
     $dbUserName,
     $dbPassword
 );
+// キーワードのデータを変数に代入
+$keyword = isset($_GET['search']) ? '%'. $_GET['search']. '%' : '%%';
 
-$sql = 'SELECT * FROM pages';
+// 作成日時のデータを取得
+$date = isset($_GET['date']) ? $_GET['date'] : '';
+
+// 指定された並び替えのデータを変数に代入
+$order = isset($_GET['order']) ? $_GET['order'] : '';
+
+// キーワードが含まれるデータを取得
+$sql = 'SELECT * FROM pages WHERE name LIKE :search OR contents LIKE :search';
+
+// 作成日時が含まれるデータを取得
+if (!empty($date)) {
+  $sql .= ' AND DATE(created_at) = :date';
+}
+
+// 並び替えの指定を設定
+if ($order === 'asc') {
+  $sql .= ' ORDER BY created_at ASC';
+} else {
+  $sql .= ' ORDER BY created_at DESC';
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':search', $keyword, PDO::PARAM_STR);
+
+if (!empty($date)) {
+  $statement->bindValue(':date', $date, PDO::PARAM_STR);
+}
 
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -28,11 +53,12 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 <body>
   <div>
-
-    <div>
-      <form action="index.php" method="get">
-        <div>
-
+    <!-- キーワード検索フォーム -->
+    <form action="privatetop.php" method="get">
+      <input type="text" name="search" placeholder="キーワードを入力"><br>
+      <!-- 作成日時のフォーム -->
+      <input type="date" name="date"><br>
+      <!-- 並び替えフォーム -->
           <label>
             <input type="radio" name="order" value="desc" class="">
             <span>新着順</span>
@@ -43,8 +69,8 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
           </label>
         </div>
         <button type="submit">送信</button>
-      </form>
-    </div>
+    </form>
+  </div>
     
     <div>
       <table border="1">

--- a/src/public/top.php
+++ b/src/public/top.php
@@ -7,10 +7,26 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
+$keyword = isset($_GET['search']) ? $_GET['search'] : '';
+// 日付選択のデータを取得
+$date = isset($_GET['date']) ? $_GET['date'] : '';
+
+$name = '%' . $keyword . '%';
+$contents = '%' . $keyword . '%';
+
+$sql = 'SELECT * FROM pages WHERE (name LIKE :name OR contents LIKE :contents)';
+
+// 日付のSQL条件を追加
+if (!empty($date)) {
+  $sql .= ' AND DATE(created_at) = :date';
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':name', $name, PDO::PARAM_STR);
+$statement->bindValue(':contents', $contents, PDO::PARAM_STR);
+if (!empty($date)) {
+  $statement->bindValue(':date', $date, PDO::PARAM_STR);
+}
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -27,22 +43,28 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 <body>
   <div>
+    <form action="top.php" method="get">
+      <input type="text" name="search" placeholder="キーワードを入力"><br>
+      <!-- 日付の選択フォームの追加 -->
+      <input type="date" name="date" value="<?php echo $date; ?>"><br>
+      <input type="submit">
+    </form>
     <div>
       <form action="index.php" method="get">
         <div>
           <label>
-            <input type="radio" name="order" value="desc" class="">
+            <input type="radio" name="order" value="desc">
             <span>新着順</span>
           </label>
           <label>
-            <input type="radio" name="order" value="asc" class="">
+            <input type="radio" name="order" value="asc">
             <span>古い順</span>
           </label>
         </div>
         <button type="submit">送信</button>
       </form>
     </div>
-
+    
     <div>
       <table border="1">
         <tr>


### PR DESCRIPTION
[作成日で絞り込む機能] かつ [検索ワードでの絞り込み] かつ [作成日の新しい順、古い順に並べ替え]をする機能を作成しました。

変更点
php

・キーワードのデータを変数に代入
・キーワードが含まれるデータを取得
・作成日時のデータを変数に代入
・作成日時が含まれるデータを取得
・指定された並び替えのデータを変数に代入
・ 並び替えの指定をorder by で設定

html
・キーワード、作成日時、並び替えのフォームを作成